### PR TITLE
Fixed Podfile issue on pod install

### DIFF
--- a/podfile
+++ b/podfile
@@ -1,2 +1,4 @@
 
-pod 'Branch'
+target 'BranchMonsterFactory' do
+	pod 'Branch'
+end


### PR DESCRIPTION
Fixed 'The dependency 'Branch' is not used in any concrete target' error when doing pod install.

With the latest Cocoapods (1.0.0), you have to specify the target that each of the pods are used in. If you don't specify the target, you'll receive an error with the message: `The dependency 'Branch' is not used in any concrete target'`

```
laptop$ pod install
Analyzing dependencies
[!] The dependency `Branch` is not used in any concrete target.
laptop$ pod install
Analyzing dependencies
Downloading dependencies
Installing Branch (0.12.1)
Generating Pods project
Integrating client project

[!] Please close any current Xcode sessions and use `BranchMonsterFactory.xcworkspace` for this project from now on.
Sending stats
Pod installation complete! There is 1 dependency from the Podfile and 1 total pod installed.
```