### PR TITLE
Added the -alternate.app.link domain

### DIFF
--- a/BranchMonsterFactory/Branchsters.entitlements
+++ b/BranchMonsterFactory/Branchsters.entitlements
@@ -35,6 +35,7 @@
 		<string>applinks:email-epsilon.branch.rocks</string>
 		<string>applinks:email-postup.branch.rocks</string>
 		<string>applinks:branchster.app.link</string>
+		<string>applinks:branchster-alternate.app.link</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Change:
Added the -alternate domain to handle Universal linking from the alternate domain. For e.g. Universal linking from Deepview and Journey CTA

Testing:
tested locally

@E-B-Smith 